### PR TITLE
feat: visibilidad de ventana de 24h de Meta en frontend y backend

### DIFF
--- a/backend/src/controllers/ContactController.ts
+++ b/backend/src/controllers/ContactController.ts
@@ -28,6 +28,7 @@ import { getClientTimeWaitingForTickets } from "./ReportsController";
 import GetContactByNumberService from "../services/ContactServices/GetContactByNumberService";
 import RemoveContactClientelicenciaService from "../services/ContactServices/RemoveContactClientelicenciaService";
 import SyncAttentionTypesService from "../services/ContactServices/SyncAttentionTypesService";
+import CheckMetaConversationWindow from "../helpers/CheckMetaConversationWindow";
 
 type IndexQuery = {
   searchParam: string;
@@ -829,4 +830,34 @@ export const syncAttentionTypes = async (
       error: error.message || "Error desconocido",
     });
   }
+};
+
+export const getConversationWindow = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const { contactId } = req.params;
+  const { whatsappId } = req.query;
+
+  if (!whatsappId) {
+    return res.status(400).json({
+      error: "Query param 'whatsappId' is required"
+    });
+  }
+
+  const contactIdNum = parseInt(contactId, 10);
+  const whatsappIdNum = parseInt(whatsappId as string, 10);
+
+  if (isNaN(contactIdNum) || isNaN(whatsappIdNum)) {
+    return res.status(400).json({
+      error: "contactId and whatsappId must be valid numbers"
+    });
+  }
+
+  const windowStatus = await CheckMetaConversationWindow(
+    contactIdNum,
+    whatsappIdNum
+  );
+
+  return res.status(200).json(windowStatus);
 };

--- a/backend/src/controllers/TicketController.ts
+++ b/backend/src/controllers/TicketController.ts
@@ -29,6 +29,8 @@ import { NOTIFICATIONTYPES } from "../constants";
 import AdvancedListTicketsService, { TicketGroupType } from "../services/TicketServices/AdvancedListTicketsService";
 import { isValidImpersonationRequest } from "../config/impersonation";
 import { logImpersonation } from "../middleware/impersonation";
+import CheckMetaConversationWindow from "../helpers/CheckMetaConversationWindow";
+import { logger } from "../utils/logger";
 
 type IndexQuery = {
   searchParam: string;
@@ -49,6 +51,7 @@ type IndexQuery = {
   viewSource: string;
   impersonatedUserId?: string; // NUEVO: ID del usuario a impersonar
   waitingTimeRanges: string; // ✅ Nuevo
+  includeWindow?: string;
 };
 
 interface TicketData {
@@ -84,7 +87,8 @@ export const index = async (req: Request, res: Response): Promise<Response> => {
     filterByUserQueue: filterByUserQueueStringified,
     clientelicenciaEtapaIds: clientelicenciaEtapaIdsStringified,
     viewSource,
-    waitingTimeRanges: waitingTimeRangesStringified // ✅ Nuevo
+    waitingTimeRanges: waitingTimeRangesStringified, // ✅ Nuevo
+    includeWindow: includeWindowStringified
   } = req.query as IndexQuery;
 
   const userId = req.user.id;
@@ -147,6 +151,9 @@ export const index = async (req: Request, res: Response): Promise<Response> => {
   if (waitingTimeRangesStringified) {
     waitingTimeRanges = JSON.parse(waitingTimeRangesStringified);
   }
+
+  // ✅ Parsear includeWindow (opt-in: solo computa si es "true")
+  const includeWindow = includeWindowStringified === "true";
 
   // SI NOS INDICA QUE SE FILTREN POR LA QUEUE DEL USUARIO Y NO HA ESPECIFICADO QUEUEIDS, ENTONCES RECUPERAMOS LAS QUEUE DEL USUARIO Y FILTRAMOS
   if (filterByUserQueue && queueIds.length === 0) {
@@ -242,6 +249,20 @@ export const index = async (req: Request, res: Response): Promise<Response> => {
         shouldSendToZapier: ticketsToUpdate.includes(ticket.id)
       };
     });
+  }
+
+  // Opt-in: compute conversationWindow for non-group tickets when includeWindow=true
+  if (includeWindow) {
+    for (const ticket of ticketsToSend) {
+      if (!ticket.isGroup && ticket.contactId && ticket.whatsappId) {
+        (ticket as any).conversationWindow = await CheckMetaConversationWindow(
+          ticket.contactId,
+          ticket.whatsappId
+        );
+      } else {
+        (ticket as any).conversationWindow = null;
+      }
+    }
   }
 
   return res.status(200).json({
@@ -526,9 +547,22 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
 export const show = async (req: Request, res: Response): Promise<Response> => {
   const { ticketId } = req.params;
 
-  const contact = await ShowTicketService(ticketId);
+  const ticket = await ShowTicketService(ticketId);
 
-  return res.status(200).json(contact);
+  // Inject conversation window status for non-group tickets
+  let conversationWindow = null;
+
+  if (!ticket.isGroup) {
+    conversationWindow = await CheckMetaConversationWindow(
+      ticket.contactId,
+      ticket.whatsappId
+    );
+  }
+
+  return res.status(200).json({
+    ...ticket.toJSON(),
+    conversationWindow
+  });
 };
 
 export const ShowParticipants = async (
@@ -650,10 +684,21 @@ export const update = async (
     const { farewellMessage } = whatsapp;
 
     if (farewellMessage) {
-      await SendWhatsAppMessage({
-        body: formatBody(farewellMessage, ticket.contact),
-        ticket
-      });
+      const windowStatus = await CheckMetaConversationWindow(
+        ticket.contactId,
+        ticket.whatsappId
+      );
+
+      if (windowStatus.isOpen) {
+        await SendWhatsAppMessage({
+          body: formatBody(farewellMessage, ticket.contact),
+          ticket
+        });
+      } else {
+        logger.info(
+          `Farewell omitido para ticket ${ticket.id}: ventana cerrada`
+        );
+      }
     }
   }
 
@@ -691,10 +736,20 @@ export const update = async (
   //   })
   // }
 
-  // console.log("ticket userId", ticket.userId);
-  // console.log("ticket oldUserId", oldUserId);
+  // Inject conversation window status for non-group tickets
+  let conversationWindow = null;
 
-  return res.status(200).json(ticket);
+  if (!ticket.isGroup) {
+    conversationWindow = await CheckMetaConversationWindow(
+      ticket.contactId,
+      ticket.whatsappId
+    );
+  }
+
+  return res.status(200).json({
+    ...ticket.toJSON(),
+    conversationWindow
+  });
 };
 
 export const remove = async (

--- a/backend/src/helpers/CheckMetaConversationWindow.ts
+++ b/backend/src/helpers/CheckMetaConversationWindow.ts
@@ -2,39 +2,78 @@ import Message from "../models/Message";
 import Ticket from "../models/Ticket";
 import { logger } from "../utils/logger";
 
-export type ConversationWindowStatus = 
-  | { isOpen: true; type: "active" }
-  | { isOpen: false; type: "new_conversation" }
-  | { isOpen: false; type: "expired" };
+export interface ConversationWindowStatus {
+  isOpen: boolean;
+  type: "active" | "expired" | "new_contact";
+  hoursRemaining: number | null;
+  lastIncomingAt: Date | null;
+}
 
 /**
  * Verifica si la ventana de conversación de 24 horas está activa
- * para un ticket de Meta API
- * 
+ * para un contacto en una conexión de WhatsApp (Meta API).
+ *
+ * Busca TODOS los tickets del contacto+whatsapp y encuentra el último mensaje
+ * entrante (fromMe: false) a través de todos esos tickets, no solo uno.
+ *
  * Según política de Meta:
  * - Solo puedes enviar mensajes de texto libre si el cliente te escribió en las últimas 24h
  * - Si el cliente nunca te ha escrito o pasaron > 24h, DEBES usar plantilla aprobada
- * 
- * @param ticket - Ticket a verificar
+ *
+ * @param contactId - ID del contacto
+ * @param whatsappId - ID de la conexión WhatsApp
  * @returns Objeto con estado de la ventana y tipo de conversación
  */
-const CheckMetaConversationWindow = async (ticket: Ticket): Promise<ConversationWindowStatus> => {
+const CheckMetaConversationWindow = async (
+  contactId: number,
+  whatsappId: number
+): Promise<ConversationWindowStatus> => {
   try {
-    // Buscar el último mensaje entrante (del cliente hacia nosotros)
+    // 1. Obtener todos los tickets del contacto+whatsapp
+    const tickets = await Ticket.findAll({
+      where: { contactId, whatsappId },
+      attributes: ["id"]
+    });
+
+    const ticketIds = tickets.map(t => t.id);
+
+    // 2. Buscar el último mensaje entrante (del cliente hacia nosotros)
+    // en CUALQUIERA de esos tickets
+    const whereCondition: any = {
+      fromMe: false
+    };
+
+    if (ticketIds.length > 0) {
+      whereCondition.ticketId = ticketIds;
+    } else {
+      // Si no hay tickets, no hay mensajes — es un contacto nuevo
+      logger.info(
+        `[CheckMetaConversationWindow] No tickets found for contact ${contactId} on whatsapp ${whatsappId}`
+      );
+      return {
+        isOpen: false,
+        type: "new_contact",
+        hoursRemaining: null,
+        lastIncomingAt: null
+      };
+    }
+
     const lastIncomingMessage = await Message.findOne({
-      where: {
-        ticketId: ticket.id,
-        fromMe: false
-      },
+      where: whereCondition,
       order: [["timestamp", "DESC"]]
     });
 
-    // Si no hay mensajes entrantes, es una conversación inicial (cliente nuevo)
+    // Si no hay mensajes entrantes, es un contacto nuevo (nunca nos escribió)
     if (!lastIncomingMessage) {
-      logger.warn(
-        `[CheckMetaConversationWindow] Ticket ${ticket.id}: Conversación inicial - Se requiere plantilla de bienvenida`
+      logger.info(
+        `[CheckMetaConversationWindow] Contact ${contactId} on whatsapp ${whatsappId}: No incoming messages found — new_contact`
       );
-      return { isOpen: false, type: "new_conversation" };
+      return {
+        isOpen: false,
+        type: "new_contact",
+        hoursRemaining: null,
+        lastIncomingAt: null
+      };
     }
 
     // Calcular tiempo transcurrido desde el último mensaje del cliente
@@ -43,24 +82,46 @@ const CheckMetaConversationWindow = async (ticket: Ticket): Promise<Conversation
     const hoursSinceLastMessage = (now - lastMessageTimestamp) / 3600;
 
     logger.info(
-      `[CheckMetaConversationWindow] Ticket ${ticket.id}: Last message ${hoursSinceLastMessage.toFixed(2)} hours ago`
+      `[CheckMetaConversationWindow] Contact ${contactId} on whatsapp ${whatsappId}: Last incoming message ${hoursSinceLastMessage.toFixed(2)} hours ago across ${ticketIds.length} ticket(s)`
     );
 
     // Ventana de 24 horas (usamos 23.5 para dar margen de seguridad)
-    const windowIsOpen = hoursSinceLastMessage < 23.5;
+    const windowIsOpen = hoursSinceLastMessage >= 0 && hoursSinceLastMessage < 23.5;
+    const lastIncomingAt = new Date(lastMessageTimestamp * 1000);
 
     if (!windowIsOpen) {
-      logger.warn(
-        `[CheckMetaConversationWindow] Ticket ${ticket.id}: 24-hour window expired (${hoursSinceLastMessage.toFixed(2)} hours) - Se requiere plantilla de reengagement`
+      const hoursRemaining = 0;
+      logger.info(
+        `[CheckMetaConversationWindow] Contact ${contactId} on whatsapp ${whatsappId}: 24-hour window expired (${hoursSinceLastMessage.toFixed(2)} hours)`
       );
-      return { isOpen: false, type: "expired" };
+      return {
+        isOpen: false,
+        type: "expired",
+        hoursRemaining,
+        lastIncomingAt
+      };
     }
 
-    return { isOpen: true, type: "active" };
+    const hoursRemaining = Math.max(0, 23.5 - hoursSinceLastMessage);
+
+    return {
+      isOpen: true,
+      type: "active",
+      hoursRemaining,
+      lastIncomingAt
+    };
   } catch (err) {
-    logger.error(`[CheckMetaConversationWindow] Error checking window for ticket ${ticket.id}:`, err);
+    logger.error(
+      `[CheckMetaConversationWindow] Error checking window for contact ${contactId} on whatsapp ${whatsappId}:`,
+      err
+    );
     // En caso de error, asumimos que es ventana expirada para forzar uso de plantilla
-    return { isOpen: false, type: "expired" };
+    return {
+      isOpen: false,
+      type: "expired",
+      hoursRemaining: 0,
+      lastIncomingAt: null
+    };
   }
 };
 

--- a/backend/src/routes/contactRoutes.ts
+++ b/backend/src/routes/contactRoutes.ts
@@ -54,6 +54,12 @@ contactRoutes.delete("/contacts/:contactId", isAuth, ContactController.remove);
 
 contactRoutes.post("/contacts/sync-attention-types", isAuth, ContactController.syncAttentionTypes);
 
+contactRoutes.get(
+  "/contacts/:contactId/conversation-window",
+  isAuth,
+  ContactController.getConversationWindow
+);
+
 export default contactRoutes;
 
 

--- a/backend/src/services/MetaServices/HandleMetaWebhookMessage.ts
+++ b/backend/src/services/MetaServices/HandleMetaWebhookMessage.ts
@@ -8,6 +8,7 @@ import CreateOrUpdateContactService from "../ContactServices/CreateOrUpdateConta
 import FindOrCreateTicketService from "../TicketServices/FindOrCreateTicketService";
 import UpdateTicketService from "../TicketServices/UpdateTicketService";
 import getAndSetBeenWaitingSinceTimestampTicketService from "../TicketServices/getAndSetBeenWaitingSinceTimestampTicketService";
+import CheckMetaConversationWindow from "../../helpers/CheckMetaConversationWindow";
 import { MetaWebhookMessage, MetaWebhookPayload } from "../../types/meta/MetaWebhookTypes";
 import DownloadMetaMedia from "./DownloadMetaMedia";
 import HandleChatbot from "./Chatbot/HandleChatbot";
@@ -251,6 +252,15 @@ const emitSocketEvents = async (
 ): Promise<void> => {
   const updatedTicket = await getAndSetBeenWaitingSinceTimestampTicketService(ticket) as Ticket;
 
+  // Compute conversation window for real-time socket updates
+  let conversationWindow = null;
+  if (!ticket.isGroup) {
+    conversationWindow = await CheckMetaConversationWindow(
+      ticket.contactId,
+      ticket.whatsappId
+    );
+  }
+
   emitEvent({
     to: [ticket.id.toString(), ticket.status, "notification"],
     event: {
@@ -270,7 +280,10 @@ const emitSocketEvents = async (
       name: "ticket",
       data: {
         action: "update",
-        ticket: updatedTicket
+        ticket: {
+          ...updatedTicket.toJSON(),
+          conversationWindow
+        }
       }
     }
   });

--- a/backend/src/services/MetaServices/SendWhatsAppMediaMeta.ts
+++ b/backend/src/services/MetaServices/SendWhatsAppMediaMeta.ts
@@ -14,6 +14,7 @@ import {
   persistMulterFile
 } from "../StorageService";
 import { sendGoogleChatMetaError } from "../../helpers/SendGoogleChatLog";
+import CheckMetaConversationWindow from "../../helpers/CheckMetaConversationWindow";
 
 interface Request {
   media: Express.Multer.File;
@@ -52,6 +53,17 @@ const SendWhatsAppMediaMeta = async ({
     // Validar credenciales
     if (!whatsapp || !whatsapp.phoneNumberId || !process.env.META_ACCESS_TOKEN) {
       throw new AppError("ERR_META_CREDENTIALS_NOT_CONFIGURED");
+    }
+
+    // Validar ventana de conversación (solo para individuales)
+    if (!ticket.isGroup) {
+      const windowStatus = await CheckMetaConversationWindow(
+        ticket.contactId,
+        ticket.whatsappId
+      );
+      if (!windowStatus.isOpen) {
+        throw new AppError("ERR_META_WINDOW_CLOSED_MEDIA", 400);
+      }
     }
 
     // Crear cliente Meta API

--- a/backend/src/services/MetaServices/SendWhatsAppMessageMeta.ts
+++ b/backend/src/services/MetaServices/SendWhatsAppMessageMeta.ts
@@ -72,7 +72,7 @@ const SendWhatsAppMessageMeta = async ({
     let windowStatus: { isOpen: boolean; type: string };
 
     if (!ticket.isGroup) {
-      windowStatus = await CheckMetaConversationWindow(ticket);
+      windowStatus = await CheckMetaConversationWindow(ticket.contactId, ticket.whatsappId);
       console.log("[SendWhatsAppMessageMeta] Estado de ventana:", windowStatus);
     } else {
       console.log("[SendWhatsAppMessageMeta] Grupo: omitiendo validación de ventana de 24h");
@@ -82,18 +82,9 @@ const SendWhatsAppMessageMeta = async ({
     let result: MetaApiSuccessResponse;
 
     if (!windowStatus.isOpen) {
-      // Ventana cerrada o conversación nueva: Enviar plantilla apropiada
-      let templateName: string;
+      const templateName = process.env.META_TEMPLATE_NAME || "info";
 
-      if (windowStatus.type === "new_conversation") {
-        // Conversación inicial - usar plantilla de bienvenida
-        templateName = process.env.META_INITIAL_TEMPLATE_NAME || "initial_conversation";
-        console.log("[SendWhatsAppMessageMeta] ⚠️ Conversación inicial, enviando plantilla de bienvenida");
-      } else {
-        // Ventana expirada - usar plantilla de reengagement
-        templateName = process.env.META_REENGAGEMENT_TEMPLATE_NAME || "reengagement_message";
-        console.log("[SendWhatsAppMessageMeta] ⚠️ Ventana cerrada, enviando plantilla de reengagement");
-      }
+      console.log(`[SendWhatsAppMessageMeta] ⚠️ Ventana cerrada, plantilla: ${templateName}`);
 
       try {
         // Limpiar el mensaje para la plantilla:
@@ -118,13 +109,7 @@ const SendWhatsAppMessageMeta = async ({
         console.log(`[SendWhatsAppMessageMeta] ✅ Plantilla ${templateName} enviada con mensaje incluido`);
       } catch (templateErr) {
         console.error("[SendWhatsAppMessageMeta] ❌ Error enviando plantilla:", templateErr);
-
-        console.log("[SendWhatsAppMessageMeta] Intentando enviar mensaje normal como fallback...");
-        result = await client.sendText({
-          to: recipientNumber,
-          body: bodyFormated,
-          replyToMessageId
-        });
+        throw templateErr;
       }
     } else {
       // Ventana abierta: Enviar mensaje normal

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
       - BILLING_INCIDENCIA_TIMEOUT_MS=${BILLING_INCIDENCIA_TIMEOUT_MS:-15000}
       - BILLING_WEBHOOK_API_KEY=${BILLING_WEBHOOK_API_KEY}
       - BILLING_INCIDENCIA_TEST_MODE=${BILLING_INCIDENCIA_TEST_MODE:-true}
+      - META_TEMPLATE_NAME=${META_TEMPLATE_NAME:-info}
       # ARGS (CHROMIUN)
       - CHROME_ARGS_CHROMIUN=--no-sandbox --disable-client-side-phishing-detection --disable-setuid-sandbox --disable-component-update --disable-default-apps --disable-popup-blocking --disable-offer-store-unmasked-wallet-cards --disable-speech-api --hide-scrollbars --mute-audio --disable-extensions --disable-dev-shm-usage --disable-accelerated-2d-canvas --no-first-run --no-default-browser-check --no-pings --password-store=basic --use-mock-keychain --no-zygote --single-process --disable-gpu
 

--- a/frontend/src/components/ConversationWindowBadge/index.js
+++ b/frontend/src/components/ConversationWindowBadge/index.js
@@ -1,0 +1,119 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Chip from "@material-ui/core/Chip";
+
+const useStyles = makeStyles(() => ({
+  badgeActive: {
+    backgroundColor: "#4caf50",
+    color: "white",
+    fontWeight: 500,
+  },
+  badgeExpiring: {
+    backgroundColor: "#ff9800",
+    color: "white",
+    fontWeight: 500,
+  },
+  badgeClosed: {
+    backgroundColor: "#f44336",
+    color: "white",
+    fontWeight: 500,
+  },
+  badgeGroup: {
+    backgroundColor: "#2196f3",
+    color: "white",
+    fontWeight: 500,
+  },
+  badgeLoading: {
+    backgroundColor: "#9e9e9e",
+    color: "white",
+    fontWeight: 500,
+  },
+}));
+
+const formatTime = (hours) => {
+  if (hours == null || isNaN(hours)) return "";
+  const totalMinutes = Math.round(hours * 60);
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+};
+
+const ConversationWindowBadge = ({ conversationWindow, isGroup }) => {
+  const classes = useStyles();
+
+  if (isGroup) {
+    return (
+      <Chip
+        size="small"
+        label="Grupo — Sin restricción"
+        className={classes.badgeGroup}
+      />
+    );
+  }
+
+  if (!conversationWindow) {
+    return (
+      <Chip
+        size="small"
+        label="···"
+        className={classes.badgeLoading}
+      />
+    );
+  }
+
+  const { isOpen, type, hoursRemaining, lastIncomingAt } = conversationWindow;
+
+  if (isOpen && type === "active") {
+    const remaining = hoursRemaining ?? 0;
+    if (remaining < 2) {
+      return (
+        <Chip
+          size="small"
+          label={`Ventana por cerrar · Quedan ${formatTime(remaining)}`}
+          className={classes.badgeExpiring}
+        />
+      );
+    }
+    return (
+      <Chip
+        size="small"
+        label={`Ventana activa · Quedan ${formatTime(remaining)}`}
+        className={classes.badgeActive}
+      />
+    );
+  }
+
+  if (type === "new_contact") {
+    return (
+      <Chip
+        size="small"
+        label="Sin historial — Se usará plantilla"
+        className={classes.badgeClosed}
+      />
+    );
+  }
+
+  if (type === "expired") {
+    const hoursAgo = lastIncomingAt
+      ? formatTime((Date.now() - new Date(lastIncomingAt).getTime()) / 3600000)
+      : "";
+    return (
+      <Chip
+        size="small"
+        label={`Ventana cerrada${hoursAgo ? ` · Último msg: hace ${hoursAgo}` : ""}`}
+        className={classes.badgeClosed}
+      />
+    );
+  }
+
+  return (
+    <Chip
+      size="small"
+      label="···"
+      className={classes.badgeLoading}
+    />
+  );
+};
+
+export default ConversationWindowBadge;

--- a/frontend/src/components/MessageInput/index.js
+++ b/frontend/src/components/MessageInput/index.js
@@ -38,6 +38,7 @@ import { useLocalStorage } from "../../hooks/useLocalStorage";
 import api from "../../services/api";
 import { i18n } from "../../translate/i18n";
 import NewPrivateNoteModal from "../NewPrivateNoteModal/index.js";
+import WindowWarningBanner from "../WindowWarningBanner";
 import RecordingTimer from "./RecordingTimer";
 
 const Mp3Recorder = new MicRecorder({ bitRate: 128 });
@@ -206,7 +207,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const MessageInput = ({ ticketStatus, ticketPrivateNote, ticketIsGroup }) => {
+const MessageInput = ({ ticketStatus, ticketPrivateNote, ticketIsGroup, conversationWindow }) => {
   const classes = useStyles();
   const { ticketId } = useParams();
 
@@ -517,6 +518,9 @@ const MessageInput = ({ ticketStatus, ticketPrivateNote, ticketIsGroup }) => {
   else {
     return (
       <Paper square elevation={0} className={classes.mainWrapper}>
+        {conversationWindow && !conversationWindow.isOpen && (
+          <WindowWarningBanner />
+        )}
         {replyingMessage && renderReplyingMessage(replyingMessage)}
         <div className={classes.newMessageBox}>
           <Hidden only={["sm", "xs"]}>

--- a/frontend/src/components/NewTicketModal/index.js
+++ b/frontend/src/components/NewTicketModal/index.js
@@ -27,6 +27,8 @@ import api from "../../services/api";
 import { i18n } from "../../translate/i18n";
 import ButtonWithSpinner from "../ButtonWithSpinner";
 import ContactModal from "../ContactModal";
+import Typography from "@material-ui/core/Typography";
+import Box from "@material-ui/core/Box";
 
 const filter = createFilterOptions({
   trim: true,
@@ -45,6 +47,8 @@ const NewTicketModal = ({ preSelectedContactId, modalOpen, onClose }) => {
   const { user } = useContext(AuthContext);
   const { whatsApps } = useContext(WhatsAppsContext);
   const [key, setKey] = useState(0);
+  const [conversationWindow, setConversationWindow] = useState(null);
+  const [windowLoading, setWindowLoading] = useState(false);
 
   useEffect(() => {
     if (!modalOpen) {
@@ -73,6 +77,32 @@ const NewTicketModal = ({ preSelectedContactId, modalOpen, onClose }) => {
     }, 500);
     return () => clearTimeout(delayDebounceFn);
   }, [searchParam, modalOpen]);
+
+  // Fetch conversation window when both contact and whatsapp are selected
+  useEffect(() => {
+    if (!selectedContact?.id || !selectedWhatsappId) {
+      setConversationWindow(null);
+      return;
+    }
+
+    setWindowLoading(true);
+    const fetchWindow = async () => {
+      try {
+        const { data } = await api.get(
+          `/contacts/${selectedContact.id}/conversation-window`,
+          { params: { whatsappId: selectedWhatsappId } }
+        );
+        setConversationWindow(data);
+      } catch (err) {
+        console.log("Error fetching conversation window:", err);
+        setConversationWindow(null);
+      } finally {
+        setWindowLoading(false);
+      }
+    };
+
+    fetchWindow();
+  }, [selectedContact?.id, selectedWhatsappId]);
 
   const handleClose = () => {
     onClose();
@@ -296,6 +326,30 @@ const NewTicketModal = ({ preSelectedContactId, modalOpen, onClose }) => {
                 })}
             </Select>
           </FormControl>
+          {conversationWindow && (
+            <Box mt={1} style={{ width: "300px" }}>
+              {conversationWindow.isOpen && conversationWindow.type === "active" ? (
+                <Typography
+                  variant="body2"
+                  style={{ color: "#4caf50", fontWeight: 500 }}
+                >
+                  🟢 Podrás enviar texto libre.
+                </Typography>
+              ) : (
+                <Typography
+                  variant="body2"
+                  style={{ color: "#f44336", fontWeight: 500 }}
+                >
+                  🔴 Se enviará como plantilla. Recomendamos un solo mensaje hasta que el cliente responda.
+                </Typography>
+              )}
+            </Box>
+          )}
+          {windowLoading && selectedContact?.id && selectedWhatsappId && (
+            <Box mt={1} style={{ width: "300px" }}>
+              <CircularProgress size={16} />
+            </Box>
+          )}
           <br />
         </DialogContent>
         <DialogActions>

--- a/frontend/src/components/Ticket/index.js
+++ b/frontend/src/components/Ticket/index.js
@@ -24,6 +24,8 @@ import TicketHeader from "../TicketHeader";
 import TicketInfo from "../TicketInfo";
 import ButtonWithSpinner from "../ButtonWithSpinner";
 import RedditIcon from '@material-ui/icons/Reddit';
+import ConversationWindowBadge from "../ConversationWindowBadge";
+import useConversationWindow from "../../hooks/useConversationWindow";
 
 import FormControl from "@material-ui/core/FormControl";
 import InputLabel from "@material-ui/core/InputLabel";
@@ -122,6 +124,8 @@ const Ticket = () => {
   const [selectMarketingCampaign, setSelectMarketingCampaign] = useState(0);
   const [clientelicenciaId, setClientelicenciaId] = useState(null);
 
+  const conversationWindowData = useConversationWindow(ticket.conversationWindow);
+
   async function searchForMicroServiceData(contactNumber) {
     try {
       const { data: microserviceNumberData } = await microserviceApi.post(
@@ -196,7 +200,15 @@ const Ticket = () => {
 
     socket.on("ticket", (data) => {
       if (data.action === "update") {
-        setTicket(data.ticket);
+        setTicket((prevTicket) => ({
+          ...prevTicket,
+          ...data.ticket,
+          // Preserve conversationWindow from socket if present; otherwise keep previous
+          conversationWindow:
+            data.ticket.conversationWindow !== undefined
+              ? data.ticket.conversationWindow
+              : prevTicket.conversationWindow,
+        }));
         setSelectMarketingCampaign(data.ticket.marketingCampaignId || 0);
         console.log("ticker actulizado", data.ticket);
       }
@@ -395,6 +407,10 @@ const Ticket = () => {
           </div>
 
           <div className={classes.ticketActionButtons}>
+            <ConversationWindowBadge
+              conversationWindow={conversationWindowData}
+              isGroup={ticket.isGroup}
+            />
             <TicketActionButtons ticket={ticket}  />
           </div>
         </TicketHeader>
@@ -484,6 +500,7 @@ const Ticket = () => {
               ticketIsGroup={ticket.isGroup}
               ticketStatus={ticket.status}
               ticketPrivateNote={ticket.privateNote}
+              conversationWindow={ticket.conversationWindow}
             />
           )}
         </ReplyMessageProvider>

--- a/frontend/src/components/WindowWarningBanner/index.js
+++ b/frontend/src/components/WindowWarningBanner/index.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Box from "@material-ui/core/Box";
+import Typography from "@material-ui/core/Typography";
+
+const useStyles = makeStyles(() => ({
+  banner: {
+    backgroundColor: "#fff8e1",
+    borderBottom: "1px solid #ffcc02",
+    padding: "4px 12px",
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+  },
+  text: {
+    fontSize: "0.72rem",
+    color: "#bf360c",
+  },
+}));
+
+const WindowWarningBanner = () => {
+  const classes = useStyles();
+
+  return (
+    <Box className={classes.banner}>
+      <Typography className={classes.text}>
+        Se recomienda enviar un solo mensaje hasta que el cliente responda y se abra la ventana de 24h, SOLO acepta texto
+      </Typography>
+    </Box>
+  );
+};
+
+export default WindowWarningBanner;

--- a/frontend/src/hooks/useConversationWindow/index.js
+++ b/frontend/src/hooks/useConversationWindow/index.js
@@ -1,0 +1,58 @@
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * Hook que recibe el objeto `conversationWindow` del ticket y
+ * mantiene un contador en tiempo real de hoursRemaining.
+ *
+ * @param {object|null} conversationWindow - Estado de ventana desde la API
+ * @returns {{ isOpen: boolean, type: string, hoursRemaining: number|null, lastIncomingAt: Date|null, isExpiringSoon: boolean }}
+ */
+const useConversationWindow = (conversationWindow) => {
+  const [liveHoursRemaining, setLiveHoursRemaining] = useState(
+    conversationWindow?.hoursRemaining ?? null
+  );
+
+  // Recalcular hoursRemaining cuando el objeto cambia (socket event)
+  useEffect(() => {
+    if (conversationWindow?.hoursRemaining != null) {
+      setLiveHoursRemaining(conversationWindow.hoursRemaining);
+    } else {
+      setLiveHoursRemaining(null);
+    }
+  }, [
+    conversationWindow?.hoursRemaining,
+    conversationWindow?.lastIncomingAt,
+    conversationWindow?.type,
+  ]);
+
+  // Decrementar hoursRemaining cada 60 segundos
+  useEffect(() => {
+    if (liveHoursRemaining == null || liveHoursRemaining <= 0) return;
+
+    const interval = setInterval(() => {
+      setLiveHoursRemaining((prev) => {
+        if (prev == null || prev <= 0) {
+          return 0;
+        }
+        return Math.max(0, prev - 1 / 60); // Decrement 1 minute
+      });
+    }, 60000);
+
+    return () => clearInterval(interval);
+  }, [liveHoursRemaining]);
+
+  const isOpen = conversationWindow?.isOpen ?? false;
+  const type = conversationWindow?.type ?? null;
+  const lastIncomingAt = conversationWindow?.lastIncomingAt ?? null;
+  const isExpiringSoon = isOpen && liveHoursRemaining != null && liveHoursRemaining < 2;
+
+  return {
+    isOpen,
+    type,
+    hoursRemaining: liveHoursRemaining,
+    lastIncomingAt,
+    isExpiringSoon,
+  };
+};
+
+export default useConversationWindow;


### PR DESCRIPTION
- Refactor CheckMetaConversationWindow a scope contacto+whatsapp
- Badge de estado de ventana en header del chat (verde/naranja/rojo)
- Banner de advertencia cuando la ventana está cerrada
- Envío automático con plantilla "info" cuando la ventana expiró
- Bloqueo de multimedia fuera de ventana
- Supresión de mensaje de despedida si ventana cerrada
- Indicador de ventana en NewTicketModal antes de crear ticket
- Sincronización en tiempo real vía socket al recibir mensaje del cliente