### PR TITLE
feat: usar metaBusinessAccountId por conexión en resolución de planti…

### DIFF
--- a/backend/src/controllers/ExternalApiController.ts
+++ b/backend/src/controllers/ExternalApiController.ts
@@ -241,12 +241,14 @@ export const sendMakeMessaginCampaign = async (
         // Resolve template structure from Meta before sending
         const resolved = await ResolveTemplateService({
           name: message.trim(),
-          language: "es"
+          language: "es",
+          wabaId: whatsapp.metaBusinessAccountId
         });
         const response = await SendTemplateService({
           to: number,
           templatePayload: resolved,
-          phoneNumberId: whatsapp.phoneNumberId
+          phoneNumberId: whatsapp.phoneNumberId,
+          wabaId: whatsapp.metaBusinessAccountId
         });
 
         const contact = await CreateOrUpdateContactService({
@@ -546,15 +548,29 @@ export const sendMarketingCampaignIntro = async (
         let payload = messageToSend.templatePayload as any;
         if (typeof payload === "string") payload = JSON.parse(payload);
 
-        const vars = Array.isArray(payload.variables) ? payload.variables : [];
+        const freshPayload = await ResolveTemplateService({
+          name: payload.name,
+          language: payload.language,
+          wabaId: whatsapp.metaBusinessAccountId
+        }).catch(() => null);
+
+        if (!freshPayload) {
+          throw new AppError(
+            `Plantilla '${payload.name}' no existe en el WABA de '${whatsapp.name}'. Créala primero en Meta Business Manager para esta conexión.`,
+            400
+          );
+        }
+
+        const vars = Array.isArray(freshPayload.variables) ? freshPayload.variables : [];
         const bodyValues = vars.length > 0
           ? [contact_nombre, contact_nombre_negocio].filter(Boolean)
           : undefined;
         response = await SendTemplateService({
           to: contacto_numero,
-          templatePayload: payload,
+          templatePayload: freshPayload,
           bodyValues,
-          phoneNumberId: whatsapp.phoneNumberId
+          phoneNumberId: whatsapp.phoneNumberId,
+          wabaId: whatsapp.metaBusinessAccountId
         });
 
         contact = await CreateOrUpdateContactService({
@@ -1852,7 +1868,8 @@ export const sendTemplateMessage = async (
   // Resolve template once (shared structure for all recipients)
   const resolved = await ResolveTemplateService({
     name: templateName.trim(),
-    language: languageCode || "es"
+    language: languageCode || "es",
+    wabaId: whatsapp.metaBusinessAccountId
   });
 
   const results: Array<{ number: string; status: string; messageId?: string; error?: string }> = [];
@@ -1864,7 +1881,8 @@ export const sendTemplateMessage = async (
         to: item.number,
         templatePayload: resolved,
         bodyValues: item.bodyParameters,
-        phoneNumberId: whatsapp.phoneNumberId
+        phoneNumberId: whatsapp.phoneNumberId,
+        wabaId: whatsapp.metaBusinessAccountId
       });
 
       if (createTickets !== false) {

--- a/backend/src/controllers/MarketingMessagingCampaignController.ts
+++ b/backend/src/controllers/MarketingMessagingCampaignController.ts
@@ -23,6 +23,7 @@ import {
 } from "../services/WbotServices/wbotMessageListener";
 import Message from "../models/Message";
 import CreateOrUpdateContactService from "../services/ContactServices/CreateOrUpdateContactService";
+import ResolveTemplateService from "../services/TemplateServices/ResolveTemplateService";
 import SendTemplateService from "../services/TemplateServices/SendTemplateService";
 import sleepPromise from "../utils/sleepPromise";
 
@@ -323,7 +324,20 @@ export const send = async (req: Request, res: Response): Promise<void> => {
               let payload = messageToSend.templatePayload as any;
               if (typeof payload === "string") payload = JSON.parse(payload);
 
-              const variables: any[] = Array.isArray(payload.variables) ? payload.variables : [];
+              const freshPayload = await ResolveTemplateService({
+                name: payload.name,
+                language: payload.language,
+                wabaId: whatsapp.metaBusinessAccountId
+              }).catch(() => null);
+
+              if (!freshPayload) {
+                throw new AppError(
+                  `Plantilla '${payload.name}' no existe en el WABA de '${whatsapp.name}'. Créala primero en Meta Business Manager para esta conexión.`,
+                  400
+                );
+              }
+
+              const variables: any[] = Array.isArray(freshPayload.variables) ? freshPayload.variables : [];
               const bodyValues: string[] = [];
               for (const v of variables) {
                 const varKey = `var_${v.index}`;
@@ -334,9 +348,10 @@ export const send = async (req: Request, res: Response): Promise<void> => {
 
               const response = await SendTemplateService({
                 to: numberObj.number,
-                templatePayload: payload,
+                templatePayload: freshPayload,
                 bodyValues: bodyValues.length > 0 ? bodyValues : undefined,
-                phoneNumberId: whatsapp.phoneNumberId
+                phoneNumberId: whatsapp.phoneNumberId,
+                wabaId: whatsapp.metaBusinessAccountId
               });
 
                 const contact = await CreateOrUpdateContactService({

--- a/backend/src/controllers/MessagingCampaignController.ts
+++ b/backend/src/controllers/MessagingCampaignController.ts
@@ -23,6 +23,7 @@ import {
 } from "../services/WbotServices/wbotMessageListener";
 import Message from "../models/Message";
 import CreateOrUpdateContactService from "../services/ContactServices/CreateOrUpdateContactService";
+import ResolveTemplateService from "../services/TemplateServices/ResolveTemplateService";
 import SendTemplateService from "../services/TemplateServices/SendTemplateService";
 import sleepPromise from "../utils/sleepPromise";
 
@@ -323,7 +324,20 @@ export const send = async (req: Request, res: Response): Promise<void> => {
               let payload = messageToSend.templatePayload as any;
               if (typeof payload === "string") payload = JSON.parse(payload);
 
-              const variables: any[] = Array.isArray(payload.variables) ? payload.variables : [];
+              const freshPayload = await ResolveTemplateService({
+                name: payload.name,
+                language: payload.language,
+                wabaId: whatsapp.metaBusinessAccountId
+              }).catch(() => null);
+
+              if (!freshPayload) {
+                throw new AppError(
+                  `Plantilla '${payload.name}' no existe en el WABA de '${whatsapp.name}'. Créala primero en Meta Business Manager para esta conexión.`,
+                  400
+                );
+              }
+
+              const variables: any[] = Array.isArray(freshPayload.variables) ? freshPayload.variables : [];
               const bodyValues: string[] = [];
               for (const v of variables) {
                 const varKey = `var_${v.index}`;
@@ -334,9 +348,10 @@ export const send = async (req: Request, res: Response): Promise<void> => {
 
               const response = await SendTemplateService({
                 to: numberObj.number,
-                templatePayload: payload,
+                templatePayload: freshPayload,
                 bodyValues: bodyValues.length > 0 ? bodyValues : undefined,
-                phoneNumberId: whatsapp.phoneNumberId
+                phoneNumberId: whatsapp.phoneNumberId,
+                wabaId: whatsapp.metaBusinessAccountId
               });
 
                 // Create contact

--- a/backend/src/controllers/TemplateController.ts
+++ b/backend/src/controllers/TemplateController.ts
@@ -1,14 +1,32 @@
 import { Request, Response } from "express";
 import AppError from "../errors/AppError";
+import Whatsapp from "../models/Whatsapp";
 import ResolveTemplateService from "../services/TemplateServices/ResolveTemplateService";
 
 export const resolve = async (req: Request, res: Response): Promise<Response> => {
-  const { name, language } = req.body;
+  const { name, language, whatsappId } = req.body;
 
   if (!name || !language) {
     throw new AppError("name and language are required", 400);
   }
 
-  const template = await ResolveTemplateService({ name, language });
+  if (!whatsappId) {
+    throw new AppError("whatsappId is required", 400);
+  }
+
+  const whatsapp = await Whatsapp.findByPk(whatsappId);
+  if (!whatsapp) {
+    throw new AppError("Whatsapp no encontrado", 404);
+  }
+
+  if (!whatsapp.metaBusinessAccountId) {
+    throw new AppError("Este número no tiene WABA ID configurado", 400);
+  }
+
+  const template = await ResolveTemplateService({
+    name,
+    language,
+    wabaId: whatsapp.metaBusinessAccountId
+  });
   return res.status(200).json(template);
 };

--- a/backend/src/services/TemplateServices/ResolveTemplateService.ts
+++ b/backend/src/services/TemplateServices/ResolveTemplateService.ts
@@ -4,6 +4,7 @@ import AppError from "../../errors/AppError";
 interface ResolveTemplateParams {
   name: string;
   language: string;
+  wabaId: string;
 }
 
 export interface ResolvedTemplate {
@@ -54,13 +55,17 @@ interface MetaTemplateResponse {
 
 const ResolveTemplateService = async ({
   name,
-  language
+  language,
+  wabaId
 }: ResolveTemplateParams): Promise<ResolvedTemplate> => {
-  const wabaId = process.env.META_BUSINESS_ACCOUNT_ID;
   const accessToken = process.env.META_ACCESS_TOKEN;
 
-  if (!wabaId || !accessToken) {
-    throw new AppError("META_BUSINESS_ACCOUNT_ID y META_ACCESS_TOKEN deben estar configurados en .env", 500);
+  if (!wabaId) {
+    throw new AppError("WABA ID no configurado para este número de WhatsApp", 400);
+  }
+
+  if (!accessToken) {
+    throw new AppError("META_ACCESS_TOKEN debe estar configurado en .env", 500);
   }
 
   const apiVersion = process.env.META_API_VERSION || "v18.0";

--- a/backend/src/services/TemplateServices/SendTemplateService.ts
+++ b/backend/src/services/TemplateServices/SendTemplateService.ts
@@ -23,13 +23,15 @@ interface SendTemplateServiceParams {
   };
   bodyValues?: string[];
   phoneNumberId: string;
+  wabaId: string;
 }
 
 const SendTemplateService = async ({
   to,
   templatePayload,
   bodyValues,
-  phoneNumberId
+  phoneNumberId,
+  wabaId
 }: SendTemplateServiceParams): Promise<any> => {
   // Re-resolve from Meta for fresh image URL and variables
   let freshHeaderUrl = templatePayload.defaultHeaderUrl || null;
@@ -38,7 +40,8 @@ const SendTemplateService = async ({
   try {
     const refreshed = await ResolveTemplateService({
       name: templatePayload.name,
-      language: templatePayload.language
+      language: templatePayload.language,
+      wabaId
     });
     freshHeaderUrl = refreshed.defaultHeaderUrl || freshHeaderUrl;
     freshVariables = refreshed.variables || freshVariables;

--- a/frontend/src/components/MarketingCampaignAutomaticMessage/index.js
+++ b/frontend/src/components/MarketingCampaignAutomaticMessage/index.js
@@ -15,6 +15,7 @@ import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
 import api from "../../services/api";
 import toastError from "../../errors/toastError";
+import useWhatsApps from "../../hooks/useWhatsApps";
 
 const useStyles = makeStyles((theme) => ({
   textField: { marginRight: 0, marginBottom: "0.5rem", flex: 1 },
@@ -33,6 +34,8 @@ const MarketingCampaignAutomaticMessage = ({ open, onClose, onSave, marketingCam
   const [templateName, setTemplateName] = useState("");
   const [templateLanguage, setTemplateLanguage] = useState("es");
   const [saving, setSaving] = useState(false);
+  const [selectedWhatsappId, setSelectedWhatsappId] = useState("");
+  const { whatsApps } = useWhatsApps();
 
   useEffect(() => {
     if (!marketingCampaignAutomaticMessageId) return;
@@ -52,9 +55,10 @@ const MarketingCampaignAutomaticMessage = ({ open, onClose, onSave, marketingCam
 
   const handleResolve = async () => {
     if (!templateName.trim()) { toast.error("Ingrese el nombre de la plantilla"); return; }
+    if (!selectedWhatsappId) { toast.error("Seleccione una conexión WhatsApp"); return; }
     setResolving(true);
     try {
-      const { data } = await api.post("/templates/resolve", { name: templateName.trim(), language: templateLanguage });
+      const { data } = await api.post("/templates/resolve", { name: templateName.trim(), language: templateLanguage, whatsappId: selectedWhatsappId });
       setResolvedTemplate(data);
       toast.success("Plantilla verificada");
     } catch (err) { toastError(err); setResolvedTemplate(null); }
@@ -78,7 +82,7 @@ const MarketingCampaignAutomaticMessage = ({ open, onClose, onSave, marketingCam
     finally { setSaving(false); }
   };
 
-  const handleClose = () => { setMessage({ order: 1, body: "" }); setResolvedTemplate(null); setTemplateName(""); setTemplateLanguage("es"); onClose(); };
+  const handleClose = () => { setMessage({ order: 1, body: "" }); setResolvedTemplate(null); setTemplateName(""); setTemplateLanguage("es"); setSelectedWhatsappId(""); onClose(); };
   const getVarCount = (tpl) => Array.isArray(tpl?.variables) ? tpl.variables.length : 0;
 
   return (
@@ -96,7 +100,16 @@ const MarketingCampaignAutomaticMessage = ({ open, onClose, onSave, marketingCam
           </Select>
         </FormControl>
 
-        <Button variant="outlined" color="primary" onClick={handleResolve} disabled={resolving || !templateName.trim()} fullWidth>
+        <FormControl variant="outlined" fullWidth size="small" className={classes.textField}>
+          <InputLabel>Conexión WhatsApp</InputLabel>
+          <Select value={selectedWhatsappId} onChange={e => setSelectedWhatsappId(e.target.value)} label="Conexión WhatsApp">
+            {whatsApps?.filter(w => w.apiType === "meta-api").map(w => (
+              <MenuItem dense key={w.id} value={w.id}>{w.name}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Button variant="outlined" color="primary" onClick={handleResolve} disabled={resolving || !templateName.trim() || !selectedWhatsappId} fullWidth>
           {resolving ? <CircularProgress size={20} /> : "Buscar en Meta"}
         </Button>
 

--- a/frontend/src/components/MessagingCampaignMessageModal/index.js
+++ b/frontend/src/components/MessagingCampaignMessageModal/index.js
@@ -15,6 +15,7 @@ import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
 import api from "../../services/api";
 import toastError from "../../errors/toastError";
+import useWhatsApps from "../../hooks/useWhatsApps";
 
 const useStyles = makeStyles((theme) => ({
   textField: { marginRight: 0, marginBottom: "0.5rem", flex: 1 },
@@ -33,6 +34,8 @@ const MessagingCampaignMessageModal = ({ open, onClose, onSave, messagingCampaig
   const [templateName, setTemplateName] = useState("");
   const [templateLanguage, setTemplateLanguage] = useState("es");
   const [saving, setSaving] = useState(false);
+  const [selectedWhatsappId, setSelectedWhatsappId] = useState("");
+  const { whatsApps } = useWhatsApps();
 
   useEffect(() => {
     if (!messagingCampaignMessageId) return;
@@ -52,9 +55,10 @@ const MessagingCampaignMessageModal = ({ open, onClose, onSave, messagingCampaig
 
   const handleResolve = async () => {
     if (!templateName.trim()) { toast.error("Ingrese el nombre de la plantilla"); return; }
+    if (!selectedWhatsappId) { toast.error("Seleccione una conexión WhatsApp"); return; }
     setResolving(true);
     try {
-      const { data } = await api.post("/templates/resolve", { name: templateName.trim(), language: templateLanguage });
+      const { data } = await api.post("/templates/resolve", { name: templateName.trim(), language: templateLanguage, whatsappId: selectedWhatsappId });
       setResolvedTemplate(data);
       toast.success("Plantilla verificada");
     } catch (err) { toastError(err); setResolvedTemplate(null); }
@@ -78,7 +82,7 @@ const MessagingCampaignMessageModal = ({ open, onClose, onSave, messagingCampaig
     finally { setSaving(false); }
   };
 
-  const handleClose = () => { setMessage({ order: 1, body: "" }); setResolvedTemplate(null); setTemplateName(""); setTemplateLanguage("es"); onClose(); };
+  const handleClose = () => { setMessage({ order: 1, body: "" }); setResolvedTemplate(null); setTemplateName(""); setTemplateLanguage("es"); setSelectedWhatsappId(""); onClose(); };
   const getVarCount = (tpl) => Array.isArray(tpl?.variables) ? tpl.variables.length : 0;
 
   return (
@@ -96,7 +100,16 @@ const MessagingCampaignMessageModal = ({ open, onClose, onSave, messagingCampaig
           </Select>
         </FormControl>
 
-        <Button variant="outlined" color="primary" onClick={handleResolve} disabled={resolving || !templateName.trim()} fullWidth>
+        <FormControl variant="outlined" fullWidth size="small" className={classes.textField}>
+          <InputLabel>Conexión WhatsApp</InputLabel>
+          <Select value={selectedWhatsappId} onChange={e => setSelectedWhatsappId(e.target.value)} label="Conexión WhatsApp">
+            {whatsApps?.filter(w => w.apiType === "meta-api").map(w => (
+              <MenuItem dense key={w.id} value={w.id}>{w.name}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Button variant="outlined" color="primary" onClick={handleResolve} disabled={resolving || !templateName.trim() || !selectedWhatsappId} fullWidth>
           {resolving ? <CircularProgress size={20} /> : "Buscar en Meta"}
         </Button>
 

--- a/frontend/src/components/WhatsAppModal/index.js
+++ b/frontend/src/components/WhatsAppModal/index.js
@@ -70,6 +70,7 @@ const WhatsAppModal = ({ open, onClose, whatsAppId }) => {
     apiType: "whatsapp-web.js",
     number: "",
     phoneNumberId: "",
+    metaBusinessAccountId: "",
   };
   const [whatsApp, setWhatsApp] = useState(initialState);
   const [selectedQueueIds, setSelectedQueueIds] = useState([]);
@@ -199,6 +200,16 @@ const WhatsAppModal = ({ open, onClose, whatsAppId }) => {
                         as={TextField}
                         label="Phone Number ID"
                         name="phoneNumberId"
+                        fullWidth
+                        variant="outlined"
+                        margin="dense"
+                      />
+                    </div>
+                    <div>
+                      <Field
+                        as={TextField}
+                        label="WABA ID (Meta Business Account ID)"
+                        name="metaBusinessAccountId"
                         fullWidth
                         variant="outlined"
                         margin="dense"

--- a/frontend/src/pages/Connections/index.js
+++ b/frontend/src/pages/Connections/index.js
@@ -351,6 +351,7 @@ const Connections = () => {
               <TableCell align="center">Número</TableCell>
               <TableCell align="center">Tipo</TableCell>
               <TableCell align="center">Phone Number ID</TableCell>
+              <TableCell align="center">WABA ID</TableCell>
               <TableCell align="center">
                 {i18n.t("connections.table.status")}
               </TableCell>
@@ -393,6 +394,9 @@ const Connections = () => {
                       </TableCell>
                       <TableCell align="center">
                         {whatsApp.apiType === "meta-api" && whatsApp.phoneNumberId ? whatsApp.phoneNumberId : "-"}
+                      </TableCell>
+                      <TableCell align="center">
+                        {whatsApp.apiType === "meta-api" && whatsApp.metaBusinessAccountId ? whatsApp.metaBusinessAccountId : "-"}
                       </TableCell>
                       <TableCell align="center">
                         {renderStatusToolTips(whatsApp)}


### PR DESCRIPTION
…llas Meta

- ResolveTemplateService y SendTemplateService aceptan wabaId como parámetro
- TemplateController obtiene wabaId desde la tabla Whatsapp
- Validación pre-envío en sendMarketingCampaignIntro, marketingMessagingCampaign/send y messagingCampaigns/send
- Selector de conexión WhatsApp en modales de mensajes de campaña
- Campo WABA ID en modal de conexión y listado de conexiones