### PR TITLE
fix: socket compartido perdía eventos en reconexiones de mantenimiento

### DIFF
--- a/backend/src/controllers/ExternalApiController.ts
+++ b/backend/src/controllers/ExternalApiController.ts
@@ -1603,3 +1603,107 @@ export const sendMessageToContact = async (
   }
 };
 
+export const getTicketsByClientelicenciaId = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const { clientelicenciaId } = req.query;
+
+  if (!clientelicenciaId) {
+    throw new AppError("Falta el parámetro clientelicenciaId", 400);
+  }
+
+  const clientelicenciaIdNum = Number(clientelicenciaId);
+  if (isNaN(clientelicenciaIdNum)) {
+    throw new AppError("clientelicenciaId debe ser un número", 400);
+  }
+
+  const contacts = await Contact.findAll({
+    attributes: ["id"],
+    include: [
+      {
+        model: ContactClientelicencia,
+        as: "contactClientelicencias",
+        where: {
+          traza_clientelicencia_id: clientelicenciaIdNum
+        },
+        required: true
+      }
+    ]
+  });
+
+  if (!contacts || contacts.length === 0) {
+    return res.status(200).json({
+      tickets: [],
+      mensaje: "No se encontraron contactos con ese clientelicenciaId"
+    });
+  }
+
+  const contactIds = contacts.map(c => c.id);
+
+  const tickets = await Ticket.findAll({
+    where: {
+      contactId: { [Op.in]: contactIds }
+    },
+    include: [
+      {
+        model: Contact,
+        as: "contact",
+        include: [
+          "extraInfo",
+          { model: Country, as: "country", required: false },
+          "contactClientelicencias"
+        ]
+      },
+      {
+        model: Queue,
+        as: "queue",
+        attributes: ["id", "name", "color"]
+      },
+      {
+        model: Whatsapp,
+        as: "whatsapp",
+        attributes: ["id", "name"]
+      },
+      {
+        model: User,
+        as: "participantUsers",
+        required: false
+      },
+      {
+        model: Message,
+        as: "messages",
+        attributes: ["id", "fromMe", "body", "mediaType", "timestamp", "isPrivate"],
+        separate: true,
+        order: [["timestamp", "DESC"]],
+        limit: 15
+      }
+    ],
+    order: [["updatedAt", "DESC"]]
+  });
+
+  const frontendUrl = process.env.FRONTEND_URL || "https://wa-app.restaurant.pe";
+
+  const result = tickets.map(ticket => {
+    const plain = ticket.get({ plain: true }) as any;
+    
+    if (plain.messages) {
+      plain.messages = plain.messages
+        .reverse()
+        .map((msg: any) => {
+          if (msg.body && msg.body.length > 1000) {
+            msg.body = msg.body.substring(0, 1000) + "...";
+          }
+          msg.date = dayjs.unix(msg.timestamp).tz("America/Lima").format("YYYY-MM-DD HH:mm:ss");
+          return msg;
+        });
+    }
+
+    plain.ticketUrl = `${frontendUrl}/tickets/${plain.id}`;
+    
+    return plain;
+  });
+
+  return res.status(200).json({ tickets: result });
+};
+

--- a/backend/src/routes/externalRoutes.ts
+++ b/backend/src/routes/externalRoutes.ts
@@ -78,4 +78,9 @@ externalRoutes.get(
   ReportsController.reportToExcelPublic
 );
 
+externalRoutes.get(
+  "/getTicketsByClientelicenciaId",
+  ExternalApiController.getTicketsByClientelicenciaId
+);
+
 export default externalRoutes;

--- a/frontend/src/components/MessagesList/index.js
+++ b/frontend/src/components/MessagesList/index.js
@@ -666,9 +666,29 @@ const MessagesList = ({ ticketId, isGroup, isAPreview }) => {
   useEffect(() => {
     const socket = openSocket();
     const currentTicketId = ticketId;
+    let hasConnectedOnce = false;
 
     socket.on("connect", () => {
       socket.emit("joinChatBox", currentTicketId);
+
+      if (hasConnectedOnce) {
+        // Reconexión: durante el gap pudieron perderse eventos appMessage.
+        // Traer la página más reciente y fusionarla (dedupe por id en el
+        // reducer), sin resetear el scroll ni las páginas antiguas cargadas.
+        fetchMessages({
+          evenToDispatch: "LOAD_NEW_MESSAGES",
+          ticketId: currentTicketId,
+          ticketsQueue: [
+            {
+              ticketId: currentTicketId,
+              pageNumber: 1,
+              isTheInitialFetch: false,
+            },
+          ],
+        });
+      } else {
+        hasConnectedOnce = true;
+      }
     });
 
     socket.on("appMessage", (data) => {

--- a/frontend/src/components/TicketsManager/index.js
+++ b/frontend/src/components/TicketsManager/index.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import { Checkbox, ListItemText } from "@material-ui/core";
 import Badge from "@material-ui/core/Badge";
@@ -227,7 +227,19 @@ const TicketsManager = () => {
 
   const [selectedClientelicenciaEtapaIds, setSelectedClientelicenciaEtapaIds] = useState([]);
   const [canImpersonate, setCanImpersonate] = useState(false);
-  
+
+  // ✅ Referencias estables para las props de TicketsList. Sin useMemo, cada
+  // render generaba arrays nuevos y el efecto de socket de TicketsList se
+  // re-suscribía en cada render, forzando reconexiones del socket compartido.
+  const cleanQueueIds = useMemo(
+    () => selectedQueueIds.filter((id) => id !== null && id !== undefined),
+    [selectedQueueIds]
+  );
+  const whatsappIdsForGeneral = useMemo(
+    () => (user.profile === "admin" ? selectedWhatsappIds : []),
+    [user.profile, selectedWhatsappIds]
+  );
+
   // Verificar permisos de impersonación al cargar
   useEffect(() => {
     const checkImpersonationPermission = async () => {
@@ -2346,10 +2358,8 @@ const TicketsManager = () => {
             >
               {/* Filtrar nulls de selectedQueueIds antes de enviar */}
               {(() => {
-                const cleanQueueIds = selectedQueueIds.filter(id => id !== null && id !== undefined);
-                // En vista GENERAL, no filtrar por whatsappIds específico para usuarios normales
-                const whatsappIdsForGeneral = user.profile === "admin" ? selectedWhatsappIds : [];
-                
+                // cleanQueueIds y whatsappIdsForGeneral vienen memoizados
+                // desde arriba para no re-suscribir el socket en cada render.
                 return (
                   <>
                     <TicketsList

--- a/frontend/src/context/ReloadDataBecauseSocketContext.js
+++ b/frontend/src/context/ReloadDataBecauseSocketContext.js
@@ -13,25 +13,34 @@ const ReloadDataBecauseSocketContextProvider = ({ children }) => {
   useEffect(() => {
     const socket = openSocket();
 
-    socket.on("connect", () => {
+    socket.on("connect", (data) => {
+      // Las reconexiones de mantenimiento (limpieza de rooms) llegan con el
+      // marcador __maintenance: no muestran avisos, pero SÍ recargan la data
+      // porque durante la reconexión pudieron perderse eventos del socket.
+      const isMaintenance = Boolean(data && data.__maintenance);
       console.log("-------------------------connect-------------------------");
 
       setWasDisConnected((prevState) => {
         if (prevState === 'disconnected') {
-          toast.success("Conexión al servidor restablecida");
+          if (!isMaintenance) {
+            toast.success("Conexión al servidor restablecida");
+          }
           setReconnect((prevState) => prevState + 1);
         }
         return 'connected';
       });
     });
 
-    socket.on("disconnect", () => {
+    socket.on("disconnect", (reason) => {
+      const isMaintenance = Boolean(reason && reason.__maintenance);
       console.log(
         ".........................disconnect........................."
       );
       setWasDisConnected((prevState) => {
         if (prevState === 'connected') {
-          toast.error("Te desconectaste del servidor, dale F5");
+          if (!isMaintenance) {
+            toast.error("Te desconectaste del servidor, dale F5");
+          }
           return 'disconnected'
         }
         return prevState;

--- a/frontend/src/services/socket-io.js
+++ b/frontend/src/services/socket-io.js
@@ -3,6 +3,32 @@ import { getNodeUrl } from "../config";
 
 const sharedSockets = new Map();
 
+// Marker passed to connect/disconnect handlers while the shared socket goes
+// through a maintenance reconnect (used to clear stale server-side rooms).
+// Handlers must NEVER be suppressed: components rejoin their rooms in these
+// callbacks. Connectivity observers use the marker to stay silent instead.
+const MAINTENANCE_EVENT = { __maintenance: true };
+
+const getStoredToken = () => {
+  const storedToken = localStorage.getItem("token");
+  return storedToken ? JSON.parse(storedToken) : null;
+};
+
+// The socket query is fixed at creation time. Keep the token in sync with
+// localStorage so reconnects don't use a stale token after refresh_token.
+const refreshSocketToken = entry => {
+  try {
+    if (entry.socket.io && entry.socket.io.opts) {
+      entry.socket.io.opts.query = {
+        ...entry.socket.io.opts.query,
+        token: getStoredToken(),
+      };
+    }
+  } catch (err) {
+    // keep previous token
+  }
+};
+
 const normalizeEventData = (event, data) => {
   if (event !== "appMessage" || !data?.message?.ticket) {
     return data;
@@ -37,11 +63,11 @@ const createSharedSocket = (key, userId, token) => {
 };
 
 function connectToSocket(userId) {
-  const storedToken = localStorage.getItem("token");
-  const token = storedToken ? JSON.parse(storedToken) : null;
+  const token = getStoredToken();
   const key = userId ? `presence:${userId}` : "application";
   const entry =
     sharedSockets.get(key) || createSharedSocket(key, userId, token);
+  refreshSocketToken(entry);
   const listeners = [];
   let disconnected = false;
   let joinedRoom = false;
@@ -52,12 +78,11 @@ function connectToSocket(userId) {
 
       const wrappedHandler = data =>
         // Internal reconnects only exist to clear stale Socket.IO rooms.
-        // Components that joined rooms must rejoin, but global connectivity
-        // observers must not show offline/online notices or reload the UI.
+        // connect/disconnect are never swallowed: components must always
+        // rejoin their rooms. Observers receive a marker to stay silent.
         entry.maintenanceReconnect &&
-        (event === "connect" || event === "disconnect") &&
-        !joinedRoom
-          ? undefined
+        (event === "connect" || event === "disconnect")
+          ? handler(MAINTENANCE_EVENT)
           : handler(normalizeEventData(event, data));
 
       listeners.push({ event, handler, wrappedHandler });
@@ -121,7 +146,8 @@ function connectToSocket(userId) {
         // Socket.IO rooms can only be left by the server. Reconnecting clears
         // rooms no longer used; remaining consumers rejoin in their callbacks.
         // Several components can unmount in the same render, so coalesce their
-        // cleanup into one silent maintenance reconnect.
+        // cleanup into one maintenance reconnect. The delay also absorbs
+        // unmount/remount bursts so the socket doesn't reconnect in a loop.
         if (!entry.reconnectTimer) {
           entry.reconnectTimer = setTimeout(() => {
             entry.reconnectTimer = null;
@@ -136,9 +162,10 @@ function connectToSocket(userId) {
                 entry.maintenanceReconnect = false;
               });
             });
+            refreshSocketToken(entry);
             entry.socket.disconnect();
             entry.socket.connect();
-          }, 50);
+          }, 300);
         }
       }
 


### PR DESCRIPTION
El socket compartido se reconectaba físicamente al desmontarse cualquier consumidor con rooms unidos. Durante la reconexión:
- se perdían los eventos appMessage/ticket emitidos en el gap
- los consumidores montados durante el gap nunca re-hacían el join (su "connect" era suprimido por maintenanceReconnect)