### PR TITLE
feat(SenExternal): nuevo endpoint

### DIFF
--- a/backend/src/controllers/ExternalApiController.ts
+++ b/backend/src/controllers/ExternalApiController.ts
@@ -20,6 +20,7 @@ import CheckIsValidContact from "../services/WbotServices/CheckIsValidContact";
 import SendApiChatbotMessage from "../services/WbotServices/SendApiChatbotMessage";
 import SendExternalWhatsAppImageMessage from "../services/WbotServices/SendExternalWhatsAppImageMessage";
 import SendExternalWhatsAppMessage from "../services/WbotServices/SendExternalWhatsAppMessage";
+import SendExternalWhatsAppMessageAddon from "../services/WbotServices/SendExternalWhatsAppMessageAddon";
 import FindGroupByNameService from "../services/WbotServices/FindGroupByNameService";
 import SendMessageToTicketService from "../services/WbotServices/SendMessageToTicketService";
 import SendMessageToContactService from "../services/WbotServices/SendMessageToContactService";
@@ -101,6 +102,21 @@ export const sendMessageV2 = async (
 
   const sendExternalWhatsAppMessage = await addMessageToQueue({
     fromNumber,
+    toNumber,
+    message,
+    mediaUrl
+  });
+
+  return res.status(200).json(sendExternalWhatsAppMessage);
+};
+
+export const sendMessageAddon = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const { toNumber, message, mediaUrl } = req.body;
+
+  const sendExternalWhatsAppMessage = await SendExternalWhatsAppMessageAddon({
     toNumber,
     message,
     mediaUrl

--- a/backend/src/routes/externalRoutes.ts
+++ b/backend/src/routes/externalRoutes.ts
@@ -13,6 +13,8 @@ externalRoutes.post("/sendMessage", ExternalApiController.sendMessage);
 
 externalRoutes.post("/sendMessageV2", ExternalApiController.sendMessageV2);
 
+externalRoutes.post("/sendMessageAddon", ExternalApiController.sendMessageAddon);
+
 externalRoutes.post(
   "/sendMakeMessaginCampaign",
   ExternalApiController.sendMakeMessaginCampaign

--- a/backend/src/services/WbotServices/SendExternalWhatsAppMessageAddon.ts
+++ b/backend/src/services/WbotServices/SendExternalWhatsAppMessageAddon.ts
@@ -1,0 +1,164 @@
+import { MessageMedia } from "whatsapp-web.js";
+import { getWbot } from "../../libs/wbot";
+import SendMessageRequest from "../../models/SendMessageRequest";
+import Whatsapp from "../../models/Whatsapp";
+
+const ELIGIBLE_CONNECTION_STATES = ["CONNECTED", "PAIRING"];
+const VALID_WBOT_STATES = ["CONNECTED", "PAIRING", "OPENING"];
+
+let currentIndex = 0;
+
+const normalizePhoneNumber = (phoneNumber: string): string => {
+  return phoneNumber.replace(/\D/g, "").trim();
+};
+
+const getEligibleConnections = async (): Promise<Whatsapp[]> => {
+  const activeConnections = await Whatsapp.findAll({
+    where: { status: ELIGIBLE_CONNECTION_STATES },
+    order: [["id", "ASC"]]
+  });
+
+  const eligible: Whatsapp[] = [];
+  for (const connection of activeConnections) {
+    const wbot = getWbot(connection.id);
+    if ((wbot as any)?.info) {
+      eligible.push(connection);
+    }
+  }
+  return eligible;
+};
+
+const getNextConnection = (connections: Whatsapp[]): Whatsapp => {
+  const nextIndex = currentIndex % connections.length;
+  currentIndex = (nextIndex + 1) % connections.length;
+  return connections[nextIndex];
+};
+
+const SendExternalWhatsAppMessageAddon = async ({
+  toNumber,
+  message,
+  mediaUrl = null
+}: {
+  toNumber: string;
+  message: string;
+  mediaUrl?: string | null;
+}) => {
+  const result: {
+    wasOk: boolean;
+    data: any;
+    logs: string[];
+    errors: string[];
+  } = {
+    wasOk: true,
+    data: null,
+    logs: [],
+    errors: []
+  };
+
+  let sendMessageRequest: SendMessageRequest | null = null;
+
+  try {
+    if (!toNumber || typeof toNumber !== "string") {
+      throw new Error("ERR_INVALID_TO_NUMBER");
+    }
+    if (!message || typeof message !== "string") {
+      throw new Error("ERR_INVALID_MESSAGE");
+    }
+
+    const cleanToNumber = normalizePhoneNumber(toNumber);
+    if (isNaN(Number(cleanToNumber))) {
+      throw new Error("ERR_INVALID_TO_NUMBER");
+    }
+
+    const connections = await getEligibleConnections();
+    if (!connections.length) {
+      throw new Error("ERR_NO_ELIGIBLE_CONNECTION");
+    }
+
+    const selectedConnection = getNextConnection(connections);
+    const fromNumber = normalizePhoneNumber(selectedConnection.number);
+    result.logs.push(`[wbot-addon] Conexion seleccionada: ${fromNumber}`);
+
+    const wbot = getWbot(selectedConnection.id);
+
+    const wbotState = await wbot.getState();
+    if (!VALID_WBOT_STATES.includes(wbotState)) {
+      throw new Error(`ERR_INVALID_STATE: ${wbotState}`);
+    }
+    result.logs.push(`[wbot-addon] Estado valido: ${wbotState}`);
+
+    if ((wbot as any)?.pupPage && !(wbot as any).pupPage.isClosed()) {
+      const patchStatus = await (wbot as any).pupPage.evaluate(() => {
+        return {
+          applied: !!(window as any).__whaticket_patch_applied,
+          wwebjsExists: typeof (window as any).WWebJS !== "undefined",
+          getChatExists: typeof (window as any).WWebJS?.getChat === "function"
+        };
+      });
+
+      if (!patchStatus.applied || !patchStatus.wwebjsExists || !patchStatus.getChatExists) {
+        throw new Error("ERR_PATCHES_NOT_APPLIED");
+      }
+      result.logs.push("[wbot-addon] Patches validados correctamente");
+    } else {
+      throw new Error("ERR_PUPPAGE_NOT_AVAILABLE");
+    }
+
+    const numberId = await wbot.getNumberId(`${cleanToNumber}@c.us`);
+    if (!numberId) {
+      throw new Error(`ERR_NUMBER_NOT_FOUND: ${cleanToNumber}`);
+    }
+    const destinationId = numberId._serialized;
+    result.logs.push(`[wbot-addon] ID destino: ${destinationId}`);
+
+    sendMessageRequest = await SendMessageRequest.create({
+      fromNumber,
+      toNumber: cleanToNumber,
+      message
+    });
+
+    let sentMessage;
+    if (mediaUrl) {
+      const media = await MessageMedia.fromUrl(mediaUrl);
+      sentMessage = await wbot.sendMessage(destinationId, media, {
+        caption: message,
+        linkPreview: false
+      });
+    } else {
+      sentMessage = await wbot.sendMessage(destinationId, message, {
+        linkPreview: false
+      });
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    try {
+      const updatedMessage = await wbot.getMessageById(sentMessage.id._serialized);
+      if (updatedMessage) sentMessage = updatedMessage;
+    } catch (refreshError) {
+      result.logs.push(`[wbot-addon] No se pudo refrescar mensaje: ${(refreshError as any)?.message}`);
+    }
+
+    if (sentMessage.ack === -1) {
+      throw new Error("ERR_ACK_REJECTED");
+    }
+
+    result.logs.push(`[wbot-addon] Mensaje enviado - ACK: ${sentMessage.ack}`);
+    result.data = sentMessage;
+
+    await sendMessageRequest.update({ status: "sent" });
+
+  } catch (error: any) {
+    result.wasOk = false;
+    result.errors.push(error?.message || "ERR_UNKNOWN");
+    result.logs.push(`[wbot-addon] Error: ${error?.message}`);
+
+    if (sendMessageRequest) {
+      await sendMessageRequest.update({ status: "failed" });
+    }
+  }
+
+  return result;
+};
+
+export default SendExternalWhatsAppMessageAddon;


### PR DESCRIPTION
# Cambios en Whaticket: Endpoint sendMessageAddon

## 1. Objetivo

Nuevo endpoint `POST /external/sendMessageAddon` para enviar mensajes de WhatsApp de forma directa (sin cola, sin delay), auto-seleccionando una conexión disponible, con las validaciones robustas de V2. Pensado para notificaciones puntuales (ej: solicitud de addon desde el microservicio).

---

## 2. Contexto

| Endpoint existente | Problema |
|---|---|
| `sendMessage` (V1) | Envío directo pero sin validaciones → falla con `Cannot read properties of undefined (reading 'getChat')` si la sesión no está inicializada |
| `sendMessageV2` (V2) | Validaciones robustas pero usa cola con delay de 45s y round-robin — complejidad innecesaria para envíos unitarios |

**Solución:** `sendMessageAddon` = envío directo de V1 + validaciones de V2 + auto-selección de conexión (round-robin simple, sin cola).

---

## 3. Archivos modificados

### 3.1. NUEVO: `backend/src/services/WbotServices/SendExternalWhatsAppMessageAddon.ts`

Servicio de envío directo:

1. Valida `toNumber` y `message` (string, formato numérico).
2. Busca conexiones WhatsApp con status `CONNECTED` / `PAIRING` y sesión inicializada (`wbot.info`).
3. Selecciona la siguiente conexión con round-robin (estado global `currentIndex`).
4. Valida estado del wbot: `CONNECTED` / `PAIRING` / `OPENING`.
5. Valida patches aplicados: `__whaticket_patch_applied`, `WWebJS`, `WWebJS.getChat`.
6. Obtiene ID destino vía `getNumberId()` (soporta `@c.us` y `@lid`).
7. Envía con `wbot.sendMessage()` (texto, o media vía `MessageMedia.fromUrl` + caption).
8. Espera 2s, refresca mensaje y valida ACK (rechaza `-1`).
9. Registra intento en `SendMessageRequest` (status `sent` / `failed`).
10. Retorna `{wasOk, data, logs, errors}` — mismo formato que V1.

**Contrato:**
```
POST /external/sendMessageAddon
Body: { "toNumber": "519XXXXXXXX", "message": "...", "mediaUrl": null }
Respuesta: { "wasOk": bool, "data": null|Message, "logs": [...], "errors": [...] }
```

**Errores:** `ERR_INVALID_TO_NUMBER`, `ERR_INVALID_MESSAGE`, `ERR_NO_ELIGIBLE_CONNECTION`, `ERR_INVALID_STATE`, `ERR_PATCHES_NOT_APPLIED`, `ERR_PUPPAGE_NOT_AVAILABLE`, `ERR_NUMBER_NOT_FOUND`, `ERR_ACK_REJECTED`.

### 3.2. MODIFICADO: `backend/src/controllers/ExternalApiController.ts`

- Import agregado: `SendExternalWhatsAppMessageAddon`.
- Método agregado:

```typescript
export const sendMessageAddon = async (
  req: Request,
  res: Response
): Promise<Response> => {
  const { toNumber, message, mediaUrl } = req.body;

  const sendExternalWhatsAppMessage = await SendExternalWhatsAppMessageAddon({
    toNumber,
    message,
    mediaUrl
  });

  return res.status(200).json(sendExternalWhatsAppMessage);
};
```

### 3.3. MODIFICADO: `backend/src/routes/externalRoutes.ts`

- Ruta agregada:

```typescript
externalRoutes.post("/sendMessageAddon", ExternalApiController.sendMessageAddon);
```

---

## 4. Verificación

| Check | Resultado |
|---|---|
| Compilación TypeScript (`npm run build` = `tsc` en Dockerfile) | OK — imagen construida sin errores |
| Registro de ruta + runtime | OK — `POST localhost:8080/external/sendMessageAddon` responde |
| Camino de error (sin conexiones) | OK — retorna `{"errors":["ERR_NO_ELIGIBLE_CONNECTION"]}` |
| Camino feliz (envío real con conexión CONNECTED) | Pendiente — smoke test en prod |

---

## 5. Deploy

```bash
# En el servidor de notificaciones-api (rama master actualizada)
docker compose up -d --build
```

El build compila con `tsc` y reinicia el contenedor sin tocar la BD (el endpoint no requiere migraciones).

---

## 6. Consideraciones

- Sin límite de envíos (a diferencia del delay de 45s de V2) → cuidado con volumen simultáneo (rate limiting de WhatsApp).
- Si no hay conexiones `CONNECTED`/`PAIRING`, responde `ERR_NO_ELIGIBLE_CONNECTION` sin efectos secundarios.
- Cada intento queda registrado en `SendMessageRequest` para monitoreo.

---

Última actualización: 12/08/2026
