### PR TITLE
feat: add Claude (Anthropic) as alternative AI provider for chat classification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ NODE_URL=
 PROXY_PORT_NODE=
 SENTRY_DSN=
 OPENAI_API_KEY=
+OPENAI_MODEL=
+# AI provider used to classify tickets/conversations: "openai" (default) or "anthropic"
+AI_PROVIDER=openai
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-sonnet-4-5
 
 # FRONTEND
 FRONTEND_PORT=80

--- a/backend/src/services/ConversationIAEvalutaion/AIChatCompletionService.ts
+++ b/backend/src/services/ConversationIAEvalutaion/AIChatCompletionService.ts
@@ -1,0 +1,105 @@
+/**
+ * Small abstraction over the different LLM providers we can use to run the
+ * conversation classification prompts (see
+ * AnalizeTicketToCreateAConversationIAEvaluationService.ts).
+ *
+ * Which provider is used is controlled by the AI_PROVIDER env var:
+ *   - "openai"    (default) uses OpenAI's Chat Completions API and attaches
+ *                 the implementation manual PDFs that were previously
+ *                 uploaded to OpenAI (see OPENAI_MANUAL_FILE_IDS below).
+ *   - "anthropic" uses Claude (Anthropic Messages API). Note: OpenAI file
+ *                 ids can't be reused by Claude, so until the manual PDFs
+ *                 are uploaded through Claude's Files API and wired in
+ *                 here, the Anthropic path runs on the text prompt alone
+ *                 (no manual attachment).
+ */
+
+type AIProvider = "openai" | "anthropic";
+
+const AI_PROVIDER = (process.env.AI_PROVIDER || "openai").toLowerCase() as AIProvider;
+
+// Manual PDFs previously uploaded to OpenAI's Files API, referenced by the
+// classification prompts.
+const OPENAI_MANUAL_FILE_IDS = [
+  "file-JgfAgvp3Fm9zZUV1Qnr3Ht",
+  "file-BoNnhpeGjGbDQRRLjNBrLh",
+];
+
+const callOpenAI = async (prompt: string): Promise<string> => {
+  const request = await fetch(
+    "https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        "model": process.env.OPENAI_MODEL || "gpt-4.1",
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              ...OPENAI_MANUAL_FILE_IDS.map(fileId => ({
+                "type": "file",
+                "file": { "file_id": fileId }
+              })),
+              {
+                "type": "text",
+                "text": prompt
+              }
+            ]
+          }
+        ]
+      })
+    }
+  );
+
+  if (!request.ok) {
+    throw new Error("Error en la petición a OpenAI: " + request.statusText);
+  }
+
+  const response = await request.json();
+
+  return response.choices[0].message.content;
+};
+
+const callAnthropic = async (prompt: string): Promise<string> => {
+  const request = await fetch(
+    "https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": process.env.ANTHROPIC_API_KEY,
+        "anthropic-version": "2023-06-01"
+      },
+      body: JSON.stringify({
+        "model": process.env.ANTHROPIC_MODEL || "claude-sonnet-4-5",
+        "max_tokens": 4096,
+        "messages": [
+          {
+            "role": "user",
+            "content": prompt
+          }
+        ]
+      })
+    }
+  );
+
+  if (!request.ok) {
+    throw new Error("Error en la petición a Claude (Anthropic): " + request.statusText);
+  }
+
+  const response = await request.json();
+
+  return response.content?.map((block: any) => block.text).join("") || "";
+};
+
+const getAIChatCompletion = async (prompt: string): Promise<string> => {
+  if (AI_PROVIDER === "anthropic") {
+    return callAnthropic(prompt);
+  }
+
+  return callOpenAI(prompt);
+};
+
+export default getAIChatCompletion;

--- a/backend/src/services/ConversationIAEvalutaion/AnalizeTicketToCreateAConversationIAEvaluationService.ts
+++ b/backend/src/services/ConversationIAEvalutaion/AnalizeTicketToCreateAConversationIAEvaluationService.ts
@@ -10,6 +10,7 @@ import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import Whatsapp from "../../models/Whatsapp";
 import { Op } from "sequelize";
+import getAIChatCompletion from "./AIChatCompletionService";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -251,53 +252,13 @@ const AnalizeTicketToCreateAConversationIAEvaluationService = async ({
       - Antes de finalizar tu respuesta, asegúrate de que el JSON sea parseable por JSON.parse().
     `;
 
-    const firstIARequest = await fetch(
-      "https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`
-        },
-        body: JSON.stringify({
-          "model": "gpt-4.1",
-          "messages": [
-            {
-              "role": "user",
-              "content": [
-                {
-                  "type": "file",
-                  "file": {
-                    "file_id": "file-JgfAgvp3Fm9zZUV1Qnr3Ht"
-                  }
-                },
-                {
-                  "type": "file",
-                  "file": {
-                    "file_id": "file-BoNnhpeGjGbDQRRLjNBrLh"
-                  }
-                },
-                {
-                  "type": "text",
-                  "text": firstPrompt
-                }
-              ]
-            }
-          ]
-        })
-      }
-    );
-
-    if (!firstIARequest.ok) {
-      throw new Error("Error en la petición a OpenAI: " + firstIARequest.statusText);
-    }
-
-    const firstIAResponse = await firstIARequest.json();
+    const firstIAResponseContent = await getAIChatCompletion(firstPrompt);
 
     response.messages.push(`--- firstIAResponse ---`);
 
-    response.data = firstIAResponse;
+    response.data = firstIAResponseContent;
 
-    const firstIAResponseData = JSON.parse(firstIAResponse.choices[0].message.content);
+    const firstIAResponseData = JSON.parse(firstIAResponseContent);
 
     const secondPrompt = `
       Eres un asistente experto en análisis de conversaciones del área de implementaciones de la empresa Restaurant.pe. A continuación, se te proporciona:
@@ -404,54 +365,13 @@ const AnalizeTicketToCreateAConversationIAEvaluationService = async ({
 
     await new Promise(resolve => setTimeout(resolve, 10000)); // Esperar 1 segundo para evitar problemas de límite de tasa
 
-    const secondIARequest = await fetch(
-      "https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`
-        },
-        body: JSON.stringify({
-          "model": "gpt-4.1",
-          "messages": [
-            {
-              "role": "user",
-              // "content": secondPrompt,
-              "content": [
-                {
-                  "type": "file",
-                  "file": {
-                    "file_id": "file-JgfAgvp3Fm9zZUV1Qnr3Ht"
-                  }
-                },
-              {
-                  "type": "file",
-                  "file": {
-                    "file_id": "file-BoNnhpeGjGbDQRRLjNBrLh"
-                  }
-                },
-                {
-                  "type": "text",
-                  "text": secondPrompt
-                }
-              ]
-            }
-          ]
-        })
-      }
-    );
+    const secondIAResponseContent = await getAIChatCompletion(secondPrompt);
 
-    if (!secondIARequest.ok) {
-      throw new Error("Error en la petición a OpenAI: " + secondIARequest.statusText);
-    }
+    response.messages.push(`--- secondIAResponse ---`);
 
-    const secondIAResponse = await secondIARequest.json();
+    response.data = secondIAResponseContent;
 
-    response.messages.push(`--- firstIAResponse ---`);
-
-    response.data = secondIAResponse;
-
-    const secondIAResponseData = JSON.parse(secondIAResponse.choices[0].message.content);
+    const secondIAResponseData = JSON.parse(secondIAResponseContent);
 
     const newConversationIAEvalutaion = await ConversationIAEvalutaion.create({
       ticketId: ticket.id,


### PR DESCRIPTION
## Qué hace

Actualmente la clasificación de conversaciones/tickets con IA (`AnalizeTicketToCreateAConversationIAEvaluationService`) solo soporta OpenAI (Chat Completions API, modelo `gpt-4.1`). Este PR agrega **Claude (Anthropic)** como proveedor alternativo, seleccionable por variable de entorno, sin cambiar el comportamiento por defecto.

## Cambios

- Nuevo `backend/src/services/ConversationIAEvalutaion/AIChatCompletionService.ts`: abstrae la llamada al LLM. Soporta `openai` (comportamiento actual, sin cambios) y `anthropic` (Claude Messages API).
- `AnalizeTicketToCreateAConversationIAEvaluationService.ts` ahora usa `getAIChatCompletion(prompt)` en lugar de hacer `fetch` directo a OpenAI en los dos pasos de evaluación/clasificación.
- `.env.example`: se agregan `AI_PROVIDER` (`openai` por defecto, o `anthropic`), `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL` y `OPENAI_MODEL`.

## Cómo probar

1. Backend: `AI_PROVIDER=openai` (default) → mismo comportamiento que hoy, sin tocar `.env`.
2. Para probar con Claude: setear `AI_PROVIDER=anthropic` y `ANTHROPIC_API_KEY` en `.env`, y disparar el flujo de clasificación de un ticket (`ConversationIAQuestionsController` / servicio de evaluación).

## Nota / limitación conocida

Los PDFs del manual de implementadores están subidos únicamente al **Files API de OpenAI** (`file-JgfAgvp3Fm9zZUV1Qnr3Ht`, `file-BoNnhpeGjGbDQRRLjNBrLh`) y se adjuntan solo en el path de OpenAI — esos `file_id` no son válidos en Claude. El path de Anthropic corre por ahora solo con el prompt de texto (sin el manual adjunto). Para tener paridad completa habría que subir esos mismos PDFs al Files API de Claude y referenciarlos en `AIChatCompletionService.ts`.

`tsc --noEmit` pasa sin errores en `backend/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)